### PR TITLE
Encode parameters correctly when building an OAuth base string

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ ohauth.qsString = function(obj) {
 ohauth.stringQs = function(str) {
     return str.split('&').reduce(function(obj, pair){
         var parts = pair.split('=');
-        obj[parts[0]] = (null === parts[1]) ?
+        obj[decodeURIComponent(parts[0])] = (null === parts[1]) ?
             '' : decodeURIComponent(parts[1]);
         return obj;
     }, {});

--- a/test/ohauth.js
+++ b/test/ohauth.js
@@ -17,6 +17,9 @@ describe('ohauth', function() {
         it('turns a querystring into an object', function() {
             expect(ohauth.stringQs('foo=1')).to.eql({ foo: 1 });
         });
+        it('handles special characters', function() {
+            expect(ohauth.stringQs('%21%27%2A%28%29=%21%27%2A%28%29')).to.eql({ "!'*()": "!'*()" });
+        });
     });
 
     describe('#nonce', function() {


### PR DESCRIPTION
Parameter key and value escaping needs to use the extended algorithm from the OAuth specification, not the standard URI escaping algorithm so we need to escape !, ', *, ( and ) characters.

This was the cause of certain comments on OSM notes showing up as anonymous, because they contained one of the problem characters.
