### PR TITLE
Updated README.md to correct ohauth.signature() example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,7 @@ ohauth.timestamp();
 ohauth.nonce();
 
 // generate a signature for an oauth request
-ohauth.signature({
-    oauth_consumer_key: '...',
-    oauth_signature_method: '...',
-    oauth_timestamp: '...',
-    oauth_nonce: '...'
-});
+ohauth.signature("myOauthSecret", "myTokenSecret", "percent&encoded&base&string");
 
 // make an oauth request.
 ohauth.xhr(method, url, auth, data, options, callback);


### PR DESCRIPTION
Changed the `ohauth.signature()` example to take in the OAuth Secret (usually provided when you register your app), Token Secret (usually obtained by requesting a request token), and the Base String (created from your request method, URL, and parameters).
