### PR TITLE
Return the xhr instance, so I can abort it later if I want to.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ ohauth.rawxhr = function(method, url, data, headers, callback) {
     xhr.open(method, url, true);
     for (var h in headers) xhr.setRequestHeader(h, headers[h]);
     xhr.send(data);
+    return xhr;
 };
 
 ohauth.xhr = function(method, url, auth, data, options, callback) {
@@ -44,7 +45,7 @@ ohauth.xhr = function(method, url, auth, data, options, callback) {
         'Content-Type': 'application/x-www-form-urlencoded'
     };
     headers.Authorization = 'OAuth ' + ohauth.authHeader(auth);
-    ohauth.rawxhr(method, url, data, headers, callback);
+    return ohauth.rawxhr(method, url, data, headers, callback);
 };
 
 ohauth.nonce = function() {

--- a/ohauth.js
+++ b/ohauth.js
@@ -38,6 +38,7 @@ ohauth.rawxhr = function(method, url, data, headers, callback) {
     xhr.open(method, url, true);
     for (var h in headers) xhr.setRequestHeader(h, headers[h]);
     xhr.send(data);
+    return xhr;
 };
 
 ohauth.xhr = function(method, url, auth, data, options, callback) {
@@ -45,7 +46,7 @@ ohauth.xhr = function(method, url, auth, data, options, callback) {
         'Content-Type': 'application/x-www-form-urlencoded'
     };
     headers.Authorization = 'OAuth ' + ohauth.authHeader(auth);
-    ohauth.rawxhr(method, url, data, headers, callback);
+    return ohauth.rawxhr(method, url, data, headers, callback);
 };
 
 ohauth.nonce = function() {


### PR DESCRIPTION
I'd like to use osm-auth to issue signed API requests, but it's not a drop in replacement for `d3.xhr` unless it returns the xhr instance - we track these and may `abort()` them later.

for context: https://github.com/openstreetmap/iD/issues/2262#issuecomment-253215027